### PR TITLE
Add backfill window slicing and retry orchestration

### DIFF
--- a/paid_social_nav/core/backfill.py
+++ b/paid_social_nav/core/backfill.py
@@ -11,6 +11,7 @@ Addresses: https://github.com/datablogin/PaidSocialNav/issues/7
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import date, timedelta
@@ -118,8 +119,9 @@ def _is_retryable_error(exc: BaseException) -> bool:
     # Meta API rate limit indicators
     if "rate limit" in msg or "too many calls" in msg:
         return True
-    # HTTP status code patterns
-    if "429" in msg or "500" in msg or "502" in msg or "503" in msg:
+    # HTTP status code patterns — use word boundaries to avoid false positives
+    # (e.g., "loaded 5002 rows" or "account ID 50032")
+    if re.search(r'\b(429|500|502|503)\b', msg):
         return True
     # Meta error code 32 = rate limit
     if "'code': 32" in msg or '"code": 32' in msg:
@@ -152,9 +154,12 @@ def _make_retryable_call(
 
     Raises:
         The original exception if all retries are exhausted or the error
-        is not retryable.
+        is not retryable.  The exception will have an ``attempts``
+        attribute attached with the actual number of attempts made.
     """
-    attempts_used = 0
+    # Mutable container so the inner function can communicate the attempt
+    # count back to the caller even when an exception is raised.
+    attempt_counter = [0]
 
     @retry(
         retry=retry_if_exception_type(_RetryableError),
@@ -163,33 +168,42 @@ def _make_retryable_call(
         reraise=True,
     )
     def _inner() -> int:
-        nonlocal attempts_used
-        attempts_used += 1
+        attempt_counter[0] += 1
         try:
             return func()
         except Exception as e:
             if _is_retryable_error(e):
                 logger.warning(
                     "Retryable error (attempt %d/%d): %s",
-                    attempts_used,
+                    attempt_counter[0],
                     max_attempts,
                     e,
                 )
                 raise _RetryableError(str(e)) from e
             raise  # Non-retryable: propagate immediately
 
+    def _attach_attempts(exc: BaseException) -> BaseException:
+        """Attach the actual attempt count to the exception."""
+        exc.attempts = attempt_counter[0]  # type: ignore[attr-defined]
+        return exc
+
     try:
         rows = _inner()
-        return rows, attempts_used
+        return rows, attempt_counter[0]
     except _RetryableError as e:
         # reraise=True causes tenacity to re-raise the _RetryableError
-        # directly; unwrap to the original exception
+        # directly; unwrap to the original exception without setting
+        # the _RetryableError as the cause (avoids confusing cause chain)
         if e.__cause__ is not None:
-            raise e.__cause__ from e
-        raise RuntimeError(str(e)) from e
+            raise _attach_attempts(e.__cause__)
+        raise _attach_attempts(RuntimeError(str(e))) from e
     except RetryError as e:
         # Fallback: unwrap the original exception from tenacity
-        raise e.last_attempt.exception() from e
+        raise _attach_attempts(e.last_attempt.exception()) from e
+    except Exception as e:
+        # Non-retryable errors: attach the attempt count so callers
+        # can report the actual number of attempts made.
+        raise _attach_attempts(e)
 
 
 def run_backfill(
@@ -282,10 +296,13 @@ def run_backfill(
 
         except Exception as e:
             elapsed = time.monotonic() - slice_start
+            # Use the actual attempt count attached by _make_retryable_call,
+            # falling back to max_retries if unavailable.
+            actual_attempts = getattr(e, "attempts", max_retries)
             slice_result = SliceResult(
                 date_range=window,
                 rows_loaded=0,
-                attempts=max_retries,
+                attempts=actual_attempts,
                 success=False,
                 error=str(e),
                 elapsed_seconds=round(elapsed, 2),
@@ -295,7 +312,7 @@ def run_backfill(
             logger.error(
                 "%s Slice failed after %d attempts: %s",
                 progress_prefix,
-                max_retries,
+                actual_attempts,
                 e,
             )
 

--- a/paid_social_nav/core/backfill.py
+++ b/paid_social_nav/core/backfill.py
@@ -1,0 +1,324 @@
+"""Backfill orchestration with window slicing and retry logic.
+
+Provides robust backfill functionality that slices large date ranges into
+configurable daily or weekly chunks, processes them sequentially with
+progress logging, and retries transient failures using tenacity with
+exponential backoff and jitter.
+
+Addresses: https://github.com/datablogin/PaidSocialNav/issues/7
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from enum import Enum
+from typing import Any, Callable
+
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from ..core.models import DateRange
+
+logger = logging.getLogger(__name__)
+
+
+class SliceGranularity(str, Enum):
+    """Granularity for backfill window slicing."""
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
+
+
+@dataclass
+class SliceResult:
+    """Result of processing a single backfill slice."""
+
+    date_range: DateRange
+    rows_loaded: int
+    attempts: int
+    success: bool
+    error: str | None = None
+    elapsed_seconds: float = 0.0
+
+
+@dataclass
+class BackfillResult:
+    """Aggregated result of a complete backfill operation."""
+
+    total_rows: int = 0
+    total_slices: int = 0
+    successful_slices: int = 0
+    failed_slices: int = 0
+    slice_results: list[SliceResult] = field(default_factory=list)
+    elapsed_seconds: float = 0.0
+
+    @property
+    def success(self) -> bool:
+        """True if all slices succeeded."""
+        return self.failed_slices == 0 and self.total_slices > 0
+
+    def summary(self) -> dict[str, Any]:
+        """Return a summary dict suitable for logging or CLI output."""
+        return {
+            "total_rows": self.total_rows,
+            "total_slices": self.total_slices,
+            "successful_slices": self.successful_slices,
+            "failed_slices": self.failed_slices,
+            "elapsed_seconds": round(self.elapsed_seconds, 2),
+        }
+
+
+def slice_date_range(
+    date_range: DateRange,
+    granularity: SliceGranularity = SliceGranularity.DAILY,
+) -> list[DateRange]:
+    """Slice a date range into smaller chunks.
+
+    Args:
+        date_range: The full date range to slice.
+        granularity: DAILY (1-day slices) or WEEKLY (7-day slices).
+
+    Returns:
+        List of DateRange objects covering the full period.
+    """
+    if date_range.since > date_range.until:
+        raise ValueError(
+            f"Invalid date range: since ({date_range.since}) is after "
+            f"until ({date_range.until})"
+        )
+
+    step_days = 1 if granularity == SliceGranularity.DAILY else 7
+    step = timedelta(days=step_days)
+
+    slices: list[DateRange] = []
+    cursor = date_range.since
+    while cursor <= date_range.until:
+        end = min(cursor + step - timedelta(days=1), date_range.until)
+        slices.append(DateRange(since=cursor, until=end))
+        cursor = end + timedelta(days=1)
+
+    return slices
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    """Check if an exception is retryable (rate limit or server error).
+
+    Detects Meta API rate limit errors (code 32, subcode 2446079) and
+    HTTP 429/5xx errors from RuntimeError messages.
+    """
+    msg = str(exc).lower()
+    # Meta API rate limit indicators
+    if "rate limit" in msg or "too many calls" in msg:
+        return True
+    # HTTP status code patterns
+    if "429" in msg or "500" in msg or "502" in msg or "503" in msg:
+        return True
+    # Meta error code 32 = rate limit
+    if "'code': 32" in msg or '"code": 32' in msg:
+        return True
+    return False
+
+
+class _RetryableError(Exception):
+    """Wrapper to signal that an error is retryable."""
+
+    pass
+
+
+def _make_retryable_call(
+    func: Callable[[], int],
+    max_attempts: int = 5,
+    min_wait: float = 1.0,
+    max_wait: float = 60.0,
+) -> tuple[int, int]:
+    """Execute a function with tenacity retry on retryable errors.
+
+    Args:
+        func: Callable that returns row count (int).
+        max_attempts: Maximum number of attempts.
+        min_wait: Minimum wait time for exponential backoff (seconds).
+        max_wait: Maximum wait time for exponential backoff (seconds).
+
+    Returns:
+        Tuple of (rows_loaded, attempts_used).
+
+    Raises:
+        The original exception if all retries are exhausted or the error
+        is not retryable.
+    """
+    attempts_used = 0
+
+    @retry(
+        retry=retry_if_exception_type(_RetryableError),
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential_jitter(initial=min_wait, max=max_wait, jitter=2),
+        reraise=True,
+    )
+    def _inner() -> int:
+        nonlocal attempts_used
+        attempts_used += 1
+        try:
+            return func()
+        except Exception as e:
+            if _is_retryable_error(e):
+                logger.warning(
+                    "Retryable error (attempt %d/%d): %s",
+                    attempts_used,
+                    max_attempts,
+                    e,
+                )
+                raise _RetryableError(str(e)) from e
+            raise  # Non-retryable: propagate immediately
+
+    try:
+        rows = _inner()
+        return rows, attempts_used
+    except _RetryableError as e:
+        # reraise=True causes tenacity to re-raise the _RetryableError
+        # directly; unwrap to the original exception
+        if e.__cause__ is not None:
+            raise e.__cause__ from e
+        raise RuntimeError(str(e)) from e
+    except RetryError as e:
+        # Fallback: unwrap the original exception from tenacity
+        raise e.last_attempt.exception() from e
+
+
+def run_backfill(
+    date_range: DateRange,
+    fetch_and_load: Callable[[DateRange], int],
+    granularity: SliceGranularity = SliceGranularity.DAILY,
+    max_retries: int = 5,
+    min_backoff: float = 1.0,
+    max_backoff: float = 60.0,
+    continue_on_error: bool = False,
+) -> BackfillResult:
+    """Run a backfill operation with window slicing and retries.
+
+    Slices the requested date range into daily or weekly chunks, processes
+    each sequentially, and retries transient failures with exponential
+    backoff and jitter.
+
+    Args:
+        date_range: Full date range to backfill.
+        fetch_and_load: Callable that takes a DateRange and returns the
+            number of rows loaded. This function should handle fetching
+            from the adapter and loading to BigQuery.
+        granularity: DAILY or WEEKLY slice granularity.
+        max_retries: Maximum retry attempts per slice.
+        min_backoff: Minimum backoff wait in seconds.
+        max_backoff: Maximum backoff wait in seconds.
+        continue_on_error: If True, continue processing remaining slices
+            after a slice fails all retries. If False (default), stop on
+            first unrecoverable failure.
+
+    Returns:
+        BackfillResult with aggregated metrics and per-slice details.
+
+    Raises:
+        Exception: Re-raises the last slice error if continue_on_error
+            is False and a slice fails all retries.
+    """
+    slices = slice_date_range(date_range, granularity)
+    total_slices = len(slices)
+
+    logger.info(
+        "Starting backfill: %d %s slices from %s to %s",
+        total_slices,
+        granularity.value,
+        date_range.since.isoformat(),
+        date_range.until.isoformat(),
+    )
+
+    result = BackfillResult(total_slices=total_slices)
+    overall_start = time.monotonic()
+
+    for idx, window in enumerate(slices, start=1):
+        slice_start = time.monotonic()
+        progress_prefix = f"[{idx}/{total_slices}]"
+
+        logger.info(
+            "%s Processing slice %s to %s",
+            progress_prefix,
+            window.since.isoformat(),
+            window.until.isoformat(),
+        )
+
+        try:
+            rows, attempts = _make_retryable_call(
+                func=lambda w=window: fetch_and_load(w),
+                max_attempts=max_retries,
+                min_wait=min_backoff,
+                max_wait=max_backoff,
+            )
+            elapsed = time.monotonic() - slice_start
+
+            slice_result = SliceResult(
+                date_range=window,
+                rows_loaded=rows,
+                attempts=attempts,
+                success=True,
+                elapsed_seconds=round(elapsed, 2),
+            )
+            result.total_rows += rows
+            result.successful_slices += 1
+
+            logger.info(
+                "%s Slice complete: %d rows in %.1fs (attempt %d/%d)",
+                progress_prefix,
+                rows,
+                elapsed,
+                attempts,
+                max_retries,
+            )
+
+        except Exception as e:
+            elapsed = time.monotonic() - slice_start
+            slice_result = SliceResult(
+                date_range=window,
+                rows_loaded=0,
+                attempts=max_retries,
+                success=False,
+                error=str(e),
+                elapsed_seconds=round(elapsed, 2),
+            )
+            result.failed_slices += 1
+
+            logger.error(
+                "%s Slice failed after %d attempts: %s",
+                progress_prefix,
+                max_retries,
+                e,
+            )
+
+            result.slice_results.append(slice_result)
+
+            if not continue_on_error:
+                result.elapsed_seconds = round(
+                    time.monotonic() - overall_start, 2
+                )
+                raise
+
+            continue
+
+        result.slice_results.append(slice_result)
+
+    result.elapsed_seconds = round(time.monotonic() - overall_start, 2)
+
+    logger.info(
+        "Backfill complete: %d/%d slices succeeded, %d total rows in %.1fs",
+        result.successful_slices,
+        result.total_slices,
+        result.total_rows,
+        result.elapsed_seconds,
+    )
+
+    return result

--- a/paid_social_nav/core/sync.py
+++ b/paid_social_nav/core/sync.py
@@ -338,7 +338,7 @@ def backfill_meta_insights(
         valid = sorted(e.value for e in SliceGranularity)
         raise ValueError(
             f"Invalid granularity {granularity!r}: must be one of {valid}"
-        )
+        ) from None
 
     adapter = MetaAdapter(access_token=access_token)
 

--- a/paid_social_nav/core/sync.py
+++ b/paid_social_nav/core/sync.py
@@ -9,7 +9,6 @@ from collections.abc import Iterable
 
 from ..adapters.meta.adapter import MetaAdapter
 from ..core.backfill import (
-    BackfillResult,
     SliceGranularity,
     run_backfill,
 )
@@ -26,8 +25,6 @@ from ..storage.bq import (
 logger = logging.getLogger(__name__)
 
 FALLBACK_ORDER: list[Entity] = [Entity.AD, Entity.ADSET, Entity.CAMPAIGN]
-
-_VALID_GRANULARITIES = {"daily", "weekly"}
 
 
 def _norm_act(account_id: str) -> str:
@@ -323,7 +320,7 @@ def backfill_meta_insights(
         Dict with keys:
             rows: Total rows loaded.
             table: Full BigQuery table path.
-            backfill: BackfillResult summary dict.
+            backfill: Backfill result summary dict.
 
     Raises:
         ValueError: If date range is invalid or granularity is not valid.
@@ -335,18 +332,13 @@ def backfill_meta_insights(
         until=date.fromisoformat(until),
     )
 
-    normalised = granularity.lower()
-    if normalised not in _VALID_GRANULARITIES:
+    try:
+        slice_granularity = SliceGranularity(granularity.lower())
+    except ValueError:
+        valid = sorted(e.value for e in SliceGranularity)
         raise ValueError(
-            f"Invalid granularity {granularity!r}: must be one of "
-            f"{sorted(_VALID_GRANULARITIES)}"
+            f"Invalid granularity {granularity!r}: must be one of {valid}"
         )
-
-    slice_granularity = (
-        SliceGranularity.WEEKLY
-        if normalised == "weekly"
-        else SliceGranularity.DAILY
-    )
 
     adapter = MetaAdapter(access_token=access_token)
 

--- a/paid_social_nav/core/sync.py
+++ b/paid_social_nav/core/sync.py
@@ -27,9 +27,44 @@ logger = logging.getLogger(__name__)
 
 FALLBACK_ORDER: list[Entity] = [Entity.AD, Entity.ADSET, Entity.CAMPAIGN]
 
+_VALID_GRANULARITIES = {"daily", "weekly"}
+
 
 def _norm_act(account_id: str) -> str:
     return account_id if account_id.startswith("act_") else f"act_{account_id}"
+
+
+def _insight_record_to_bq_row(ir: Any, act: str) -> dict[str, Any]:
+    """Convert an InsightRecord to a BigQuery row dict.
+
+    This is the single source of truth for mapping adapter insight records
+    to the BigQuery ``insights`` table schema, used by both
+    ``sync_meta_insights`` and ``backfill_meta_insights``.
+    """
+    raw = ir.raw or {}
+    ad_id = raw.get("ad_id")
+    adset_id = raw.get("adset_id")
+    campaign_id = raw.get("campaign_id")
+
+    return {
+        "date": ir.date.isoformat(),
+        "level": ir.level.value,
+        "account_global_id": f"meta:account:{act}",
+        "campaign_global_id": f"meta:campaign:{campaign_id}"
+        if campaign_id
+        else None,
+        "adset_global_id": f"meta:adset:{adset_id}"
+        if adset_id
+        else None,
+        "ad_global_id": f"meta:ad:{ad_id}" if ad_id else None,
+        "impressions": ir.impressions,
+        "clicks": ir.clicks,
+        "spend": ir.spend,
+        "conversions": ir.conversions,
+        "ctr": ir.ctr,
+        "frequency": ir.frequency,
+        "raw_metrics": raw,
+    }
 
 
 @dataclass(frozen=True)
@@ -181,32 +216,7 @@ def sync_meta_insights(
                         date_preset=dp,
                         page_size=page_size,
                     ):
-                        raw = ir.raw or {}
-                        ad_id = raw.get("ad_id")
-                        adset_id = raw.get("adset_id")
-                        campaign_id = raw.get("campaign_id")
-
-                        rows.append(
-                            {
-                                "date": ir.date.isoformat(),
-                                "level": ir.level.value,
-                                "account_global_id": f"meta:account:{act}",
-                                "campaign_global_id": f"meta:campaign:{campaign_id}"
-                                if campaign_id
-                                else None,
-                                "adset_global_id": f"meta:adset:{adset_id}"
-                                if adset_id
-                                else None,
-                                "ad_global_id": f"meta:ad:{ad_id}" if ad_id else None,
-                                "impressions": ir.impressions,
-                                "clicks": ir.clicks,
-                                "spend": ir.spend,
-                                "conversions": ir.conversions,
-                                "ctr": ir.ctr,
-                                "frequency": ir.frequency,
-                                "raw_metrics": raw,
-                            }
-                        )
+                        rows.append(_insight_record_to_bq_row(ir, act))
                     # Load per chunk to keep memory bounded and enable dedup
                     if rows:
                         load_json_rows(
@@ -316,7 +326,7 @@ def backfill_meta_insights(
             backfill: BackfillResult summary dict.
 
     Raises:
-        ValueError: If date range is invalid.
+        ValueError: If date range is invalid or granularity is not valid.
         Exception: Re-raises slice errors if continue_on_error is False.
     """
     act = _norm_act(account_id)
@@ -325,9 +335,16 @@ def backfill_meta_insights(
         until=date.fromisoformat(until),
     )
 
+    normalised = granularity.lower()
+    if normalised not in _VALID_GRANULARITIES:
+        raise ValueError(
+            f"Invalid granularity {granularity!r}: must be one of "
+            f"{sorted(_VALID_GRANULARITIES)}"
+        )
+
     slice_granularity = (
         SliceGranularity.WEEKLY
-        if granularity.lower() == "weekly"
+        if normalised == "weekly"
         else SliceGranularity.DAILY
     )
 
@@ -348,32 +365,7 @@ def backfill_meta_insights(
             date_range=window,
             page_size=page_size,
         ):
-            raw = ir.raw or {}
-            ad_id = raw.get("ad_id")
-            adset_id = raw.get("adset_id")
-            campaign_id = raw.get("campaign_id")
-
-            rows.append(
-                {
-                    "date": ir.date.isoformat(),
-                    "level": ir.level.value,
-                    "account_global_id": f"meta:account:{act}",
-                    "campaign_global_id": f"meta:campaign:{campaign_id}"
-                    if campaign_id
-                    else None,
-                    "adset_global_id": f"meta:adset:{adset_id}"
-                    if adset_id
-                    else None,
-                    "ad_global_id": f"meta:ad:{ad_id}" if ad_id else None,
-                    "impressions": ir.impressions,
-                    "clicks": ir.clicks,
-                    "spend": ir.spend,
-                    "conversions": ir.conversions,
-                    "ctr": ir.ctr,
-                    "frequency": ir.frequency,
-                    "raw_metrics": raw,
-                }
-            )
+            rows.append(_insight_record_to_bq_row(ir, act))
 
         if rows:
             load_json_rows(

--- a/paid_social_nav/core/sync.py
+++ b/paid_social_nav/core/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from time import sleep
@@ -7,6 +8,11 @@ from typing import Any
 from collections.abc import Iterable
 
 from ..adapters.meta.adapter import MetaAdapter
+from ..core.backfill import (
+    BackfillResult,
+    SliceGranularity,
+    run_backfill,
+)
 from ..core.enums import DatePreset, Entity
 from ..core.models import DateRange
 from ..storage.bq import (
@@ -16,6 +22,8 @@ from ..storage.bq import (
     ensure_insights_table,
     load_json_rows,
 )
+
+logger = logging.getLogger(__name__)
 
 FALLBACK_ORDER: list[Entity] = [Entity.AD, Entity.ADSET, Entity.CAMPAIGN]
 
@@ -262,3 +270,133 @@ def sync_meta_insights(
         current_level = FALLBACK_ORDER[next_index]
 
     return {"rows": total, "table": f"{project_id}.{dataset}.{INSIGHTS_TABLE}"}
+
+
+def backfill_meta_insights(
+    *,
+    account_id: str,
+    project_id: str,
+    dataset: str,
+    access_token: str,
+    level: Entity = Entity.CAMPAIGN,
+    since: str,
+    until: str,
+    granularity: str = "daily",
+    max_retries: int = 5,
+    min_backoff: float = 1.0,
+    max_backoff: float = 60.0,
+    continue_on_error: bool = False,
+    page_size: int = 500,
+) -> dict[str, Any]:
+    """Backfill Meta insights over a large date range with window slicing and retries.
+
+    Slices the requested period into daily or weekly chunks, processes each
+    sequentially with progress logging, and retries transient failures
+    (rate limits, server errors) using exponential backoff with jitter.
+
+    Args:
+        account_id: Meta ad account id (act_* or numeric).
+        project_id: GCP project ID for BigQuery.
+        dataset: BigQuery dataset name.
+        access_token: Meta API access token.
+        level: Insights hierarchy level (default: CAMPAIGN).
+        since: Start date as YYYY-MM-DD string.
+        until: End date as YYYY-MM-DD string.
+        granularity: Slice granularity - "daily" or "weekly".
+        max_retries: Maximum retry attempts per slice.
+        min_backoff: Minimum backoff wait in seconds.
+        max_backoff: Maximum backoff wait in seconds.
+        continue_on_error: If True, continue after slice failures.
+        page_size: Page size for Meta insights API.
+
+    Returns:
+        Dict with keys:
+            rows: Total rows loaded.
+            table: Full BigQuery table path.
+            backfill: BackfillResult summary dict.
+
+    Raises:
+        ValueError: If date range is invalid.
+        Exception: Re-raises slice errors if continue_on_error is False.
+    """
+    act = _norm_act(account_id)
+    dr = DateRange(
+        since=date.fromisoformat(since),
+        until=date.fromisoformat(until),
+    )
+
+    slice_granularity = (
+        SliceGranularity.WEEKLY
+        if granularity.lower() == "weekly"
+        else SliceGranularity.DAILY
+    )
+
+    adapter = MetaAdapter(access_token=access_token)
+
+    # Ensure BQ infrastructure
+    ensure_dataset(project_id, dataset)
+    ensure_insights_table(project_id, dataset)
+    ensure_dim_ad_table(project_id, dataset)
+
+    def _fetch_and_load_slice(window: DateRange) -> int:
+        """Fetch a single slice from Meta API and load to BigQuery."""
+        rows: list[dict[str, Any]] = []
+
+        for ir in adapter.fetch_insights(
+            level=level,
+            account_id=act,
+            date_range=window,
+            page_size=page_size,
+        ):
+            raw = ir.raw or {}
+            ad_id = raw.get("ad_id")
+            adset_id = raw.get("adset_id")
+            campaign_id = raw.get("campaign_id")
+
+            rows.append(
+                {
+                    "date": ir.date.isoformat(),
+                    "level": ir.level.value,
+                    "account_global_id": f"meta:account:{act}",
+                    "campaign_global_id": f"meta:campaign:{campaign_id}"
+                    if campaign_id
+                    else None,
+                    "adset_global_id": f"meta:adset:{adset_id}"
+                    if adset_id
+                    else None,
+                    "ad_global_id": f"meta:ad:{ad_id}" if ad_id else None,
+                    "impressions": ir.impressions,
+                    "clicks": ir.clicks,
+                    "spend": ir.spend,
+                    "conversions": ir.conversions,
+                    "ctr": ir.ctr,
+                    "frequency": ir.frequency,
+                    "raw_metrics": raw,
+                }
+            )
+
+        if rows:
+            load_json_rows(
+                project_id=project_id,
+                dataset=dataset,
+                table=INSIGHTS_TABLE,
+                rows=rows,
+            )
+
+        return len(rows)
+
+    backfill_result = run_backfill(
+        date_range=dr,
+        fetch_and_load=_fetch_and_load_slice,
+        granularity=slice_granularity,
+        max_retries=max_retries,
+        min_backoff=min_backoff,
+        max_backoff=max_backoff,
+        continue_on_error=continue_on_error,
+    )
+
+    return {
+        "rows": backfill_result.total_rows,
+        "table": f"{project_id}.{dataset}.{INSIGHTS_TABLE}",
+        "backfill": backfill_result.summary(),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "google-auth>=2.0.0",
   "google-api-python-client>=2.0.0",
   "fastmcp>=2.13.1",
+  "tenacity>=8.2.0",
 ]
 
 [project.scripts]

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,407 @@
+"""Tests for backfill orchestration with window slicing and retries."""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paid_social_nav.core.backfill import (
+    BackfillResult,
+    SliceGranularity,
+    SliceResult,
+    _is_retryable_error,
+    _make_retryable_call,
+    run_backfill,
+    slice_date_range,
+)
+from paid_social_nav.core.models import DateRange
+
+
+class TestSliceDateRange:
+    """Tests for date range slicing."""
+
+    def test_daily_slicing_single_day(self):
+        """Single day produces one slice."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 1))
+        slices = slice_date_range(dr, SliceGranularity.DAILY)
+        assert len(slices) == 1
+        assert slices[0].since == date(2025, 1, 1)
+        assert slices[0].until == date(2025, 1, 1)
+
+    def test_daily_slicing_one_week(self):
+        """7 days produces 7 daily slices."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 7))
+        slices = slice_date_range(dr, SliceGranularity.DAILY)
+        assert len(slices) == 7
+        # Each slice is exactly one day
+        for s in slices:
+            assert s.since == s.until
+
+    def test_daily_slicing_90_days(self):
+        """90-day backfill produces 90 daily slices."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 3, 31))
+        slices = slice_date_range(dr, SliceGranularity.DAILY)
+        assert len(slices) == 90
+        # Verify continuity: each slice starts the day after the previous ends
+        for i in range(1, len(slices)):
+            assert slices[i].since == slices[i - 1].until + timedelta(days=1)
+
+    def test_weekly_slicing_one_week(self):
+        """7 days with weekly granularity produces 1 slice."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 7))
+        slices = slice_date_range(dr, SliceGranularity.WEEKLY)
+        assert len(slices) == 1
+        assert slices[0].since == date(2025, 1, 1)
+        assert slices[0].until == date(2025, 1, 7)
+
+    def test_weekly_slicing_90_days(self):
+        """90-day window with weekly slicing produces ~13 slices."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 3, 31))
+        slices = slice_date_range(dr, SliceGranularity.WEEKLY)
+        assert len(slices) == 13  # 90/7 = 12.86, rounds up to 13
+        # First slice starts on the first day
+        assert slices[0].since == date(2025, 1, 1)
+        # Last slice ends on the last day
+        assert slices[-1].until == date(2025, 3, 31)
+
+    def test_weekly_slicing_partial_last_week(self):
+        """10-day range with weekly slicing has a partial last slice."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 10))
+        slices = slice_date_range(dr, SliceGranularity.WEEKLY)
+        assert len(slices) == 2
+        # First slice: 7 days
+        assert slices[0].since == date(2025, 1, 1)
+        assert slices[0].until == date(2025, 1, 7)
+        # Second slice: remaining 3 days
+        assert slices[1].since == date(2025, 1, 8)
+        assert slices[1].until == date(2025, 1, 10)
+
+    def test_invalid_date_range_raises(self):
+        """Since after until raises ValueError."""
+        dr = DateRange(since=date(2025, 3, 1), until=date(2025, 1, 1))
+        with pytest.raises(ValueError, match="Invalid date range"):
+            slice_date_range(dr, SliceGranularity.DAILY)
+
+    def test_slices_cover_full_range(self):
+        """Verify that slices cover every day in the range without gaps or overlaps."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 4, 30))
+        for granularity in [SliceGranularity.DAILY, SliceGranularity.WEEKLY]:
+            slices = slice_date_range(dr, granularity)
+            assert slices[0].since == dr.since
+            assert slices[-1].until == dr.until
+            # No gaps between slices
+            for i in range(1, len(slices)):
+                assert slices[i].since == slices[i - 1].until + timedelta(days=1)
+
+
+class TestRetryableErrorDetection:
+    """Tests for _is_retryable_error helper."""
+
+    def test_rate_limit_message(self):
+        assert _is_retryable_error(RuntimeError("Rate limit exceeded"))
+
+    def test_too_many_calls(self):
+        assert _is_retryable_error(RuntimeError("Too many calls to API"))
+
+    def test_http_429(self):
+        assert _is_retryable_error(RuntimeError("HTTP 429 Too Many Requests"))
+
+    def test_http_500(self):
+        assert _is_retryable_error(RuntimeError("HTTP 500 Internal Server Error"))
+
+    def test_http_502(self):
+        assert _is_retryable_error(RuntimeError("502 Bad Gateway"))
+
+    def test_http_503(self):
+        assert _is_retryable_error(RuntimeError("503 Service Unavailable"))
+
+    def test_meta_error_code_32(self):
+        assert _is_retryable_error(
+            RuntimeError("Meta error: {'code': 32, 'message': 'rate limited'}")
+        )
+
+    def test_non_retryable_error(self):
+        assert not _is_retryable_error(RuntimeError("Invalid credentials"))
+
+    def test_non_retryable_value_error(self):
+        assert not _is_retryable_error(ValueError("Bad date format"))
+
+
+class TestMakeRetryableCall:
+    """Tests for _make_retryable_call with tenacity retry logic."""
+
+    def test_success_on_first_attempt(self):
+        """Function succeeds immediately, no retries needed."""
+        func = MagicMock(return_value=42)
+        rows, attempts = _make_retryable_call(func, max_attempts=3)
+        assert rows == 42
+        assert attempts == 1
+        func.assert_called_once()
+
+    def test_retry_on_rate_limit_then_succeed(self):
+        """Retries on rate limit error, then succeeds."""
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("Rate limit exceeded")
+            return 10
+
+        rows, attempts = _make_retryable_call(
+            flaky, max_attempts=5, min_wait=0.01, max_wait=0.02
+        )
+        assert rows == 10
+        assert attempts == 3
+
+    def test_non_retryable_error_propagates_immediately(self):
+        """Non-retryable errors are raised immediately without retry."""
+        func = MagicMock(side_effect=ValueError("Invalid input"))
+        with pytest.raises(ValueError, match="Invalid input"):
+            _make_retryable_call(func, max_attempts=3)
+        func.assert_called_once()
+
+    def test_all_retries_exhausted(self):
+        """Raises original error when all retries are exhausted."""
+        func = MagicMock(side_effect=RuntimeError("Rate limit exceeded"))
+        with pytest.raises(RuntimeError, match="Rate limit exceeded"):
+            _make_retryable_call(
+                func, max_attempts=3, min_wait=0.01, max_wait=0.02
+            )
+        assert func.call_count == 3
+
+
+class TestRunBackfill:
+    """Tests for the main run_backfill orchestrator."""
+
+    def test_successful_backfill(self):
+        """All slices succeed."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 3))
+        fetch_and_load = MagicMock(return_value=10)
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.DAILY,
+            max_retries=3,
+            min_backoff=0.01,
+            max_backoff=0.02,
+        )
+
+        assert result.total_rows == 30
+        assert result.total_slices == 3
+        assert result.successful_slices == 3
+        assert result.failed_slices == 0
+        assert result.success
+        assert len(result.slice_results) == 3
+        assert all(s.success for s in result.slice_results)
+        assert fetch_and_load.call_count == 3
+
+    def test_backfill_with_empty_slices(self):
+        """Some slices return zero rows (no data for that day)."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 3))
+        # First day has data, second doesn't, third does
+        fetch_and_load = MagicMock(side_effect=[5, 0, 3])
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.DAILY,
+            max_retries=3,
+            min_backoff=0.01,
+            max_backoff=0.02,
+        )
+
+        assert result.total_rows == 8
+        assert result.successful_slices == 3
+        assert result.failed_slices == 0
+
+    def test_backfill_stops_on_error_by_default(self):
+        """Default behavior: stops on first unrecoverable failure."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 3))
+        # Second slice always fails with non-retryable error
+        fetch_and_load = MagicMock(
+            side_effect=[10, ValueError("Bad data"), 10]
+        )
+
+        with pytest.raises(ValueError, match="Bad data"):
+            run_backfill(
+                date_range=dr,
+                fetch_and_load=fetch_and_load,
+                granularity=SliceGranularity.DAILY,
+                max_retries=3,
+                min_backoff=0.01,
+                max_backoff=0.02,
+            )
+
+    def test_backfill_continue_on_error(self):
+        """With continue_on_error=True, processes all slices despite failures."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 3))
+        # Second slice fails with non-retryable error
+        fetch_and_load = MagicMock(
+            side_effect=[10, ValueError("Bad data"), 15]
+        )
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.DAILY,
+            max_retries=3,
+            min_backoff=0.01,
+            max_backoff=0.02,
+            continue_on_error=True,
+        )
+
+        assert result.total_rows == 25
+        assert result.successful_slices == 2
+        assert result.failed_slices == 1
+        assert not result.success
+        failed = [s for s in result.slice_results if not s.success]
+        assert len(failed) == 1
+        assert "Bad data" in failed[0].error
+
+    def test_backfill_retries_rate_limits(self):
+        """Rate limit errors are retried with backoff."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 1))
+        call_count = 0
+
+        def flaky_fetch(window):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("Rate limit exceeded")
+            return 5
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=flaky_fetch,
+            granularity=SliceGranularity.DAILY,
+            max_retries=5,
+            min_backoff=0.01,
+            max_backoff=0.02,
+        )
+
+        assert result.total_rows == 5
+        assert result.successful_slices == 1
+        assert result.slice_results[0].attempts == 3
+
+    def test_backfill_weekly_granularity(self):
+        """Weekly slicing works for a 14-day range."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 14))
+        fetch_and_load = MagicMock(return_value=50)
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.WEEKLY,
+            max_retries=3,
+            min_backoff=0.01,
+            max_backoff=0.02,
+        )
+
+        assert result.total_slices == 2
+        assert result.total_rows == 100
+
+    def test_backfill_90_day_window(self):
+        """90-day backfill creates 90 daily slices."""
+        start = date(2025, 1, 1)
+        end = start + timedelta(days=89)
+        dr = DateRange(since=start, until=end)
+        fetch_and_load = MagicMock(return_value=5)
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.DAILY,
+            max_retries=3,
+            min_backoff=0.01,
+            max_backoff=0.02,
+        )
+
+        assert result.total_slices == 90
+        assert result.total_rows == 450
+        assert result.successful_slices == 90
+
+    def test_backfill_result_summary(self):
+        """BackfillResult.summary() returns correct dict."""
+        result = BackfillResult(
+            total_rows=100,
+            total_slices=10,
+            successful_slices=9,
+            failed_slices=1,
+            elapsed_seconds=45.678,
+        )
+        summary = result.summary()
+        assert summary["total_rows"] == 100
+        assert summary["total_slices"] == 10
+        assert summary["successful_slices"] == 9
+        assert summary["failed_slices"] == 1
+        assert summary["elapsed_seconds"] == 45.68
+
+    def test_backfill_progress_logging(self, caplog):
+        """Verify progress logging during backfill."""
+        import logging
+
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 3))
+        fetch_and_load = MagicMock(return_value=10)
+
+        with caplog.at_level(logging.INFO):
+            run_backfill(
+                date_range=dr,
+                fetch_and_load=fetch_and_load,
+                granularity=SliceGranularity.DAILY,
+                max_retries=3,
+                min_backoff=0.01,
+                max_backoff=0.02,
+            )
+
+        log_text = caplog.text
+        assert "[1/3]" in log_text
+        assert "[2/3]" in log_text
+        assert "[3/3]" in log_text
+        assert "Backfill complete" in log_text
+
+
+class TestSliceResult:
+    """Tests for SliceResult dataclass."""
+
+    def test_successful_slice_result(self):
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 1))
+        sr = SliceResult(
+            date_range=dr, rows_loaded=10, attempts=1, success=True
+        )
+        assert sr.success
+        assert sr.error is None
+
+    def test_failed_slice_result(self):
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 1))
+        sr = SliceResult(
+            date_range=dr,
+            rows_loaded=0,
+            attempts=5,
+            success=False,
+            error="Rate limit exceeded",
+        )
+        assert not sr.success
+        assert sr.error == "Rate limit exceeded"
+
+
+class TestBackfillResult:
+    """Tests for BackfillResult dataclass."""
+
+    def test_success_property(self):
+        result = BackfillResult(
+            total_slices=3, successful_slices=3, failed_slices=0
+        )
+        assert result.success
+
+    def test_failure_property(self):
+        result = BackfillResult(
+            total_slices=3, successful_slices=2, failed_slices=1
+        )
+        assert not result.success
+
+    def test_empty_result_not_success(self):
+        result = BackfillResult(total_slices=0)
+        assert not result.success

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -460,7 +460,6 @@ class TestBackfillMetaInsightsGranularityValidation:
 
     def test_invalid_granularity_raises_value_error(self):
         """backfill_meta_insights rejects unsupported granularity values."""
-        from unittest.mock import patch
         from paid_social_nav.core.sync import backfill_meta_insights
 
         with pytest.raises(ValueError, match="Invalid granularity"):
@@ -476,7 +475,7 @@ class TestBackfillMetaInsightsGranularityValidation:
 
     def test_valid_granularity_daily_accepted(self):
         """backfill_meta_insights accepts 'daily' granularity."""
-        from unittest.mock import patch, MagicMock as MM
+        from unittest.mock import patch
         from paid_social_nav.core.sync import backfill_meta_insights
         from paid_social_nav.core.backfill import BackfillResult
 
@@ -496,7 +495,7 @@ class TestBackfillMetaInsightsGranularityValidation:
 
     def test_valid_granularity_weekly_accepted(self):
         """backfill_meta_insights accepts 'weekly' (case-insensitive)."""
-        from unittest.mock import patch, MagicMock as MM
+        from unittest.mock import patch
         from paid_social_nav.core.sync import backfill_meta_insights
         from paid_social_nav.core.backfill import BackfillResult
 

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -441,3 +441,78 @@ class TestBackfillResult:
     def test_empty_result_not_success(self):
         result = BackfillResult(total_slices=0)
         assert not result.success
+
+
+class TestMakeRetryableCallEdgeCases:
+    """Edge-case tests for _make_retryable_call."""
+
+    def test_func_returning_zero_succeeds(self):
+        """A function returning 0 (falsy int) should succeed, not be treated as failure."""
+        func = MagicMock(return_value=0)
+        rows, attempts = _make_retryable_call(func, max_attempts=3)
+        assert rows == 0
+        assert attempts == 1
+        func.assert_called_once()
+
+
+class TestBackfillMetaInsightsGranularityValidation:
+    """Tests for granularity validation in backfill_meta_insights."""
+
+    def test_invalid_granularity_raises_value_error(self):
+        """backfill_meta_insights rejects unsupported granularity values."""
+        from unittest.mock import patch
+        from paid_social_nav.core.sync import backfill_meta_insights
+
+        with pytest.raises(ValueError, match="Invalid granularity"):
+            backfill_meta_insights(
+                account_id="act_123",
+                project_id="proj",
+                dataset="ds",
+                access_token="tok",
+                since="2025-01-01",
+                until="2025-01-07",
+                granularity="monthly",
+            )
+
+    def test_valid_granularity_daily_accepted(self):
+        """backfill_meta_insights accepts 'daily' granularity."""
+        from unittest.mock import patch, MagicMock as MM
+        from paid_social_nav.core.sync import backfill_meta_insights
+        from paid_social_nav.core.backfill import BackfillResult
+
+        mock_result = BackfillResult(total_rows=5, total_slices=1, successful_slices=1)
+
+        with patch("paid_social_nav.core.sync.MetaAdapter"),              patch("paid_social_nav.core.sync.ensure_dataset"),              patch("paid_social_nav.core.sync.ensure_insights_table"),              patch("paid_social_nav.core.sync.ensure_dim_ad_table"),              patch("paid_social_nav.core.sync.run_backfill", return_value=mock_result):
+            result = backfill_meta_insights(
+                account_id="act_123",
+                project_id="proj",
+                dataset="ds",
+                access_token="tok",
+                since="2025-01-01",
+                until="2025-01-01",
+                granularity="daily",
+            )
+            assert result["rows"] == 5
+
+    def test_valid_granularity_weekly_accepted(self):
+        """backfill_meta_insights accepts 'weekly' (case-insensitive)."""
+        from unittest.mock import patch, MagicMock as MM
+        from paid_social_nav.core.sync import backfill_meta_insights
+        from paid_social_nav.core.backfill import BackfillResult
+
+        mock_result = BackfillResult(total_rows=10, total_slices=1, successful_slices=1)
+
+        with patch("paid_social_nav.core.sync.MetaAdapter"),              patch("paid_social_nav.core.sync.ensure_dataset"),              patch("paid_social_nav.core.sync.ensure_insights_table"),              patch("paid_social_nav.core.sync.ensure_dim_ad_table"),              patch("paid_social_nav.core.sync.run_backfill", return_value=mock_result) as mock_bf:
+            result = backfill_meta_insights(
+                account_id="act_123",
+                project_id="proj",
+                dataset="ds",
+                access_token="tok",
+                since="2025-01-01",
+                until="2025-01-14",
+                granularity="Weekly",
+            )
+            assert result["rows"] == 10
+            # Verify SliceGranularity.WEEKLY was passed to run_backfill
+            call_kwargs = mock_bf.call_args[1]
+            assert call_kwargs["granularity"] == SliceGranularity.WEEKLY

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,7 +1,7 @@
 """Tests for backfill orchestration with window slicing and retries."""
 
 from datetime import date, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -126,6 +126,14 @@ class TestRetryableErrorDetection:
     def test_non_retryable_value_error(self):
         assert not _is_retryable_error(ValueError("Bad date format"))
 
+    def test_no_false_positive_on_embedded_500(self):
+        """Ensure '500' inside a larger number does not trigger a match."""
+        assert not _is_retryable_error(RuntimeError("loaded 5002 rows"))
+
+    def test_no_false_positive_on_account_id(self):
+        """Ensure '502' inside an account ID does not trigger a match."""
+        assert not _is_retryable_error(RuntimeError("account ID 50032"))
+
 
 class TestMakeRetryableCall:
     """Tests for _make_retryable_call with tenacity retry logic."""
@@ -170,6 +178,14 @@ class TestMakeRetryableCall:
                 func, max_attempts=3, min_wait=0.01, max_wait=0.02
             )
         assert func.call_count == 3
+
+    def test_non_retryable_error_reports_single_attempt(self):
+        """A non-retryable error on attempt 1 should report attempts=1."""
+        func = MagicMock(side_effect=ValueError("Bad data"))
+        with pytest.raises(ValueError) as exc_info:
+            _make_retryable_call(func, max_attempts=5)
+        # The exception should NOT claim 5 attempts were made
+        assert getattr(exc_info.value, "attempts", None) == 1
 
 
 class TestRunBackfill:
@@ -260,6 +276,26 @@ class TestRunBackfill:
         failed = [s for s in result.slice_results if not s.success]
         assert len(failed) == 1
         assert "Bad data" in failed[0].error
+
+    def test_backfill_failed_slice_reports_actual_attempts(self):
+        """A non-retryable error on attempt 1 should report attempts=1, not max_retries."""
+        dr = DateRange(since=date(2025, 1, 1), until=date(2025, 1, 1))
+        fetch_and_load = MagicMock(side_effect=ValueError("Bad data"))
+
+        result = run_backfill(
+            date_range=dr,
+            fetch_and_load=fetch_and_load,
+            granularity=SliceGranularity.DAILY,
+            max_retries=5,
+            min_backoff=0.01,
+            max_backoff=0.02,
+            continue_on_error=True,
+        )
+
+        assert result.failed_slices == 1
+        failed = result.slice_results[0]
+        assert not failed.success
+        assert failed.attempts == 1  # NOT 5
 
     def test_backfill_retries_rate_limits(self):
         """Rate limit errors are retried with backoff."""


### PR DESCRIPTION
## Summary
- Add robust backfill orchestration that slices large date ranges into daily/weekly chunks for reliable Meta Insights API ingestion
- Implement exponential backoff and retry with tenacity for rate limit (429) and server error (5xx) handling
- Integrate backfill with existing sync module via new `backfill_meta_insights()` function

## Changes

### New: `paid_social_nav/core/backfill.py`
- `slice_date_range()` - splits DateRange into DAILY or WEEKLY chunks with no gaps or overlaps
- `run_backfill()` - orchestrator that processes slices sequentially with:
  - Progress logging (`[N/M] Processing slice ...`)
  - Per-slice retry with exponential backoff + jitter via tenacity
  - Configurable `continue_on_error` to process remaining slices after failures
  - `BackfillResult` with per-slice details and aggregate metrics
- `_is_retryable_error()` - detects Meta rate limits (code 32), HTTP 429/5xx
- `_make_retryable_call()` - tenacity wrapper with `wait_exponential_jitter`

### Updated: `paid_social_nav/core/sync.py`
- New `backfill_meta_insights()` function that wires the backfill orchestrator to the existing `MetaAdapter.fetch_insights()` and BigQuery loader
- Returns structured result with `backfill` summary dict

### Updated: `pyproject.toml`
- Added `tenacity>=8.2.0` dependency

### New: `tests/test_backfill.py`
- 35 tests covering: daily/weekly slicing, 90-day backfill, retry on rate limits, error propagation, continue-on-error, progress logging, result summaries

## Test plan
- [x] All 35 new tests pass
- [x] Existing tests unaffected (pre-existing Python 3.13 compat issue in `test_base_adapter` is not related)
- [ ] Manual test: run backfill against Fleming account with `level=campaign` across 90-day range
- [ ] Verify progress logs show `N/M days done` pattern
- [ ] Confirm BQ has non-zero rows for known delivery dates

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)